### PR TITLE
fix: don't use 'bin' as build to make work on mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,19 +3,16 @@
   "version": "1.0.0",
   "description": "Base theme for Molgenis",
   "main": "index.js",
-  "bin" : {
-    "mg-theme" : "./mg-theme.js"
-  },
   "type": "module",
   "engines": {
     "node": ">=13.0.0"
   },
   "scripts": {
-    "build": "mg-theme build --optimize",
-    "build-all": "mg-theme build --all --optimize",
-    "dev": "mg-theme dev",
+    "build": "node mg-theme.js build --optimize",
+    "build-all": "node mg-theme.js build --all --optimize",
+    "dev": "node mg-theme.js dev",
     "proxy": "docker-compose --env-file .env --file ./docker/dc-proxy.yml up",
-    "theme": "mg-theme"
+    "theme": "node mg-theme.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
the 'bin' option doesn't work on checkout. I suppose it would work with chmod command, but this is easier.