### PR TITLE
refactor: allow custom font paths

### DIFF
--- a/docker/nginx/localhost.tpl
+++ b/docker/nginx/localhost.tpl
@@ -14,66 +14,17 @@ server {
   error_log /dev/stdout info;
 
   location @handle_redirect {
-      proxy_cache unpkg;
-      # drop routing information from urls that do not start with `/dist/`
-      proxy_cache_use_stale timeout;
-      rewrite ^/([^/]*)/([^/]*)/(?!dist/).*$ /$1/$2 last;
-      error_page 301 302 307 = @handle_redirect;
-      set $frontend_host 'https://unpkg.com';
-      set $saved_redirect_location '$upstream_http_location';
-      proxy_pass $frontend_host$saved_redirect_location;
+    # drop routing information from urls that do not start with `/dist/`
+    rewrite ^/([^/]*)/([^/]*)/(?!dist/).*$ /$1/$2 last;
+
+    proxy_intercept_errors on;
+    error_page 301 302 307 = @handle_redirect;
+    set $frontend_host 'https://unpkg.com';
+    set $saved_redirect_location '$upstream_http_location';
+    proxy_pass $frontend_host$saved_redirect_location;
+    # Do not cache these redirects too long
+    expires 10m;
   }
-
-  #
-  # Pre-Theme refactor uses different endpoints. Keep these around
-  # until https://github.com/molgenis/molgenis/pull/9110/ is merged
-  # and released.
-
-  # HACK: Override a legacy hardcoded Bootstrap 3 theme with our own (login)
-  location /css/bootstrap.min.css {
-      add_header Last-Modified $date_gmt;
-      add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
-      root /usr/share/nginx/html/;
-      rewrite ^ /css/mg-${MG_THEME_LOCAL}-3.css break;
-  }
-
-  location /css/bootstrap-3/${MG_THEME_PROXY} {
-      add_header Last-Modified $date_gmt;
-      add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
-      root /usr/share/nginx/html/;
-      rewrite ^ /css/mg-${MG_THEME_LOCAL}-3.css break;
-  }
-
-  location /css/bootstrap-4/${MG_THEME_PROXY} {
-      add_header Last-Modified $date_gmt;
-      add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
-      root /usr/share/nginx/html/;
-      rewrite ^ /css/mg-${MG_THEME_LOCAL}-4.css break;
-  }
-
-  location /css/bootstrap-3/mg-${MG_THEME_LOCAL}-3.css.map {
-    add_header Last-Modified $date_gmt;
-    add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
-    root /usr/share/nginx/html/;
-    rewrite ^ /css/mg-${MG_THEME_LOCAL}-3.css.map break;
-  }
-
-  location /css/bootstrap-4/mg-${MG_THEME_LOCAL}-4.css.map {
-    add_header Last-Modified $date_gmt;
-    add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
-    root /usr/share/nginx/html/;
-    rewrite ^ /css/mg-${MG_THEME_LOCAL}-4.css.map break;
-  }
-
-  # HACK: Override a hardcoded theme from de2
-  location /@molgenis-ui/data-explorer/dist/bootstrap-molgenis-blue.min.css {
-      add_header Last-Modified $date_gmt;
-      add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
-      root /usr/share/nginx/html/;
-      rewrite ^ /css/mg-${MG_THEME_LOCAL}-4.css break;
-  }
-  # End of Pre-Theme refactor endpoints...
-
 
   location /@molgenis-experimental/ {
       proxy_cache unpkg;
@@ -85,15 +36,16 @@ server {
   location /@molgenis-ui/ {
       proxy_cache unpkg;
       proxy_pass https://unpkg.com/@molgenis-ui/;
-      proxy_buffers 8 1024k;
-      proxy_buffer_size 2k;
+      proxy_intercept_errors on;
+      recursive_error_pages on;
+      error_page 301 302 307 = @handle_redirect;
   }
 
   # New molgenis-theme proxy endpoint must expose /themes/ and
   # /fonts. In this case locally, on production pointing to unpkg, e.g.
   # https://unpkg.com/browse/@molgenis-ui/molgenis-theme@latest/themes/
   # https://unpkg.com/browse/@molgenis-ui/molgenis-theme@latest/fonts/
-  location ~ /themes|fonts {
+  location ~ "^/(themes|fonts)" {
       autoindex on;
       root /usr/share/nginx/html/dist;
   }

--- a/scss/molgenis/_variables.scss
+++ b/scss/molgenis/_variables.scss
@@ -34,6 +34,8 @@ $mg-color-white: #fff !default;
 // Font config:
 // Rem units are assumed but not applied here. This makes it easier to
 // calculate between px (Bootstrap 3) and rem (Bootstrap 4).
+$mg-font-path: '/@molgenis-ui/molgenis-theme/dist/fonts/';
+
 $mg-font-size-large: 0.95 * $mg-unit !default;
 $mg-font-size-base: 0.9 * $mg-unit !default;
 $mg-font-size-small: 0.8 * $mg-unit !default;

--- a/scss/molgenis/theme-3/_boot.scss
+++ b/scss/molgenis/theme-3/_boot.scss
@@ -1,0 +1,2 @@
+// Bootstrap 3 calculates with pixels
+$mg-unit: 16px;

--- a/scss/molgenis/theme-3/_theme.scss
+++ b/scss/molgenis/theme-3/_theme.scss
@@ -1,6 +1,3 @@
-// Bootstrap 3 calculates with pixels
-$mg-unit: 16px;
-
 @import '../variables';
 @import './variables';
 @import 'bootstrap';

--- a/scss/molgenis/theme-3/_variables.scss
+++ b/scss/molgenis/theme-3/_variables.scss
@@ -17,7 +17,7 @@ $grid-float-breakpoint: 1000px;
 $grid-float-breakpoint-max: 1300px;
 $grid-gutter-width: 16px;
 
-$icon-font-path: '/fonts/';
+$icon-font-path: $mg-font-path;
 
 $input-border: $mg-color-grey-400;
 $input-border-radius: 0;

--- a/scss/molgenis/theme-4/_boot.scss
+++ b/scss/molgenis/theme-4/_boot.scss
@@ -1,0 +1,2 @@
+// Bootstrap 4 calculates with rems
+$mg-unit: 1rem;

--- a/scss/molgenis/theme-4/_theme.scss
+++ b/scss/molgenis/theme-4/_theme.scss
@@ -1,6 +1,3 @@
-// Bootstrap 4 calculates with rems
-$mg-unit: 1rem;
-
 @import '../variables';
 @import './variables';
 @import 'bootstrap-scss/bootstrap';

--- a/themes/ase/theme-3.scss
+++ b/themes/ase/theme-3.scss
@@ -1,4 +1,3 @@
-@import url('//fonts.googleapis.com/css?family=Roboto');
-
+@import 'molgenis/theme-3/boot';
 @import './variables';
 @import 'molgenis/theme-3/theme';

--- a/themes/ase/theme-4.scss
+++ b/themes/ase/theme-4.scss
@@ -1,4 +1,3 @@
-@import url('//fonts.googleapis.com/css?family=Roboto');
-
+@import 'molgenis/theme-4/boot';
 @import './variables';
 @import 'molgenis/theme-4/theme';

--- a/themes/bbmri-nl/theme-3.scss
+++ b/themes/bbmri-nl/theme-3.scss
@@ -1,2 +1,3 @@
+@import 'molgenis/theme-3/boot';
 @import './variables';
 @import 'molgenis/theme-3/theme';

--- a/themes/bbmri-nl/theme-4.scss
+++ b/themes/bbmri-nl/theme-4.scss
@@ -1,2 +1,3 @@
+@import 'molgenis/theme-4/boot';
 @import './variables';
 @import 'molgenis/theme-4/theme';

--- a/themes/data-management/theme-3.scss
+++ b/themes/data-management/theme-3.scss
@@ -1,4 +1,3 @@
-@import url('//fonts.googleapis.com/css?family=Roboto');
-
+@import 'molgenis/theme-3/boot';
 @import './variables';
 @import 'molgenis/theme-3/theme';

--- a/themes/data-management/theme-4.scss
+++ b/themes/data-management/theme-4.scss
@@ -1,4 +1,3 @@
-@import url('//fonts.googleapis.com/css?family=Roboto');
-
+@import 'molgenis/theme-4/boot';
 @import './variables';
 @import 'molgenis/theme-4/theme';

--- a/themes/hfgp/theme-3.scss
+++ b/themes/hfgp/theme-3.scss
@@ -1,2 +1,3 @@
+@import 'molgenis/theme-3/boot';
 @import './variables';
 @import 'molgenis/theme-3/theme';

--- a/themes/hfgp/theme-4.scss
+++ b/themes/hfgp/theme-4.scss
@@ -1,2 +1,3 @@
+@import 'molgenis/theme-4/boot';
 @import './variables';
 @import 'molgenis/theme-4/theme';

--- a/themes/lifecycle/_variables.scss
+++ b/themes/lifecycle/_variables.scss
@@ -1,8 +1,10 @@
+@import 'molgenis/variables';
+
 @font-face {
     font-family: 'Varela Round';
     font-style: normal;
     font-weight: 400;
-    src: local('Varela Round Regular'),url('/fonts/Varela-round-400.woff2') format('woff2'), url('/fonts/Varela-round-400.woff') format('woff');
+    src: local('Varela Round Regular'),url('#{$mg-font-path}Varela-round-400.woff2') format('woff2'), url('#{$mg-font-path}Varela-round-400.woff') format('woff');
 }
 
 $mg-color-primary: #005c8f;

--- a/themes/lifecycle/theme-3.scss
+++ b/themes/lifecycle/theme-3.scss
@@ -1,2 +1,3 @@
+@import 'molgenis/theme-3/boot';
 @import './variables';
 @import 'molgenis/theme-3/theme';

--- a/themes/lifecycle/theme-4.scss
+++ b/themes/lifecycle/theme-4.scss
@@ -1,2 +1,3 @@
+@import 'molgenis/theme-4/boot';
 @import './variables';
 @import 'molgenis/theme-4/theme';

--- a/themes/molgenis-blue/_variables.scss
+++ b/themes/molgenis-blue/_variables.scss
@@ -1,52 +1,50 @@
-// molgenis-<color> themes all inherit from molgenis-blue
-$mg-color-primary: #017ffd !default; // "MAIN BLUE"
-$mg-color-secondary: #005ec4 !default; // "SUB BLUE"
+@import 'molgenis/variables';
 
 @font-face {
     font-family: 'Bebas Neue';
     font-style: normal;
     font-weight: 400;
-    src: local('Bebas Neue Regular'), url('/fonts/BebasNeue-Regular.woff2') format('woff2'), url('/fonts/BebasNeue-Regular.woff') format('woff');
+    src: local('Bebas Neue Regular'), url('#{$mg-font-path}BebasNeue-Regular.woff2') format('woff2'), url('#{$mg-font-path}BebasNeue-Regular.woff') format('woff');
 }
 
 @font-face {
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 400;
-    src: url('/fonts/IBMPlexSans-Medium.woff2') format('woff2'), url('/fonts/IBMPlexSans-Regular.woff') format('woff');
+    src: url('#{$mg-font-path}IBMPlexSans-Medium.woff2') format('woff2'), url('#{$mg-font-path}IBMPlexSans-Regular.woff') format('woff');
 }
 
 @font-face {
     font-family: 'IBM Plex Sans';
     font-style: italic;
     font-weight: 400;
-    src: url('/fonts/IBMPlexSans-MediumItalic.woff2') format('woff2'), url('/fonts/IBMPlexSans-SemiBold.woff') format('woff');
+    src: url('#{$mg-font-path}IBMPlexSans-MediumItalic.woff2') format('woff2'), url('#{$mg-font-path}IBMPlexSans-SemiBold.woff') format('woff');
 }
 
 @font-face {
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 600;
-    src: url('/fonts/IBMPlexSans-SemiBold.woff2') format('woff2'), url('/fonts/IBMPlexSans-SemiBold.woff') format('woff');
+    src: url('#{$mg-font-path}IBMPlexSans-SemiBold.woff2') format('woff2'), url('#{$mg-font-path}IBMPlexSans-SemiBold.woff') format('woff');
 }
 
 @font-face {
     font-family: 'IBM Plex Sans';
     font-style: normal;
     font-weight: 700;
-    src: url('/fonts/IBMPlexSans-Bold.woff2') format('woff2'), url('/fonts/IBMPlexSans-Bold.woff') format('woff');
+    src: url('#{$mg-font-path}IBMPlexSans-Bold.woff2') format('woff2'), url('#{$mg-font-path}IBMPlexSans-Bold.woff') format('woff');
 }
 
 @font-face {
     font-family: 'IBM Plex Mono';
     font-style: normal;
     font-weight: 400;
-    src: url('/fonts/IBMPlexMono-Regular.woff2') format('woff2'), url('/fonts/IBMPlexMono-Regular.woff') format('woff');
+    src: url('#{$mg-font-path}IBMPlexMono-Regular.woff2') format('woff2'), url('#{$mg-font-path}IBMPlexMono-Regular.woff') format('woff');
 }
 
 @font-face {
     font-family: 'FontAwesome';
     font-style: normal;
     font-weight: 400;
-    src: url('/fonts/fontawesome-4.7.woff2') format('woff2'), url('/fonts/fontawesome-4.7.woff') format('woff');
+    src: url('#{$mg-font-path}fontawesome-4.7.woff2') format('woff2'), url('#{$mg-font-path}fontawesome-4.7.woff') format('woff');
 }

--- a/themes/molgenis-blue/theme-3.scss
+++ b/themes/molgenis-blue/theme-3.scss
@@ -1,2 +1,3 @@
+@import 'molgenis/theme-3/boot';
 @import './variables';
 @import 'molgenis/theme-3/theme';

--- a/themes/molgenis-blue/theme-4.scss
+++ b/themes/molgenis-blue/theme-4.scss
@@ -1,2 +1,3 @@
+@import 'molgenis/theme-4/boot';
 @import './variables';
 @import 'molgenis/theme-4/theme';

--- a/themes/rd-connect/_variables.scss
+++ b/themes/rd-connect/_variables.scss
@@ -1,9 +1,10 @@
+@import 'molgenis/variables';
 
 @font-face {
     font-family: 'Roboto';
     font-style: normal;
     font-weight: 400;
-    src: local('Roboto'),url('/fonts/Roboto-Regular.woff2') format('woff2'), url('/fonts/Roboto-Regular.woff') format('woff');
+    src: local('Roboto'),url('#{$mg-font-path}Roboto-Regular.woff2') format('woff2'), url('#{$mg-font-path}Roboto-Regular.woff') format('woff');
 }
 
 $mg-color-primary: #5c9966;

--- a/themes/rd-connect/theme-3.scss
+++ b/themes/rd-connect/theme-3.scss
@@ -1,2 +1,3 @@
+@import 'molgenis/theme-3/boot';
 @import './variables';
 @import 'molgenis/theme-3/theme';

--- a/themes/rd-connect/theme-4.scss
+++ b/themes/rd-connect/theme-4.scss
@@ -1,2 +1,3 @@
+@import 'molgenis/theme-4/boot';
 @import './variables';
 @import 'molgenis/theme-4/theme';


### PR DESCRIPTION
This introduces a theme boot file, so that base
variables can be imported from a custom theme,
without having to take care of setting low-level
variables like $mg-units in each custom theme.
Instead, each custom theme imports the boot file.