### PR TITLE
fix: Use base font for menu items in bs3/4 theme

### DIFF
--- a/scss/molgenis/_custom.scss
+++ b/scss/molgenis/_custom.scss
@@ -12,10 +12,12 @@ html {
 }
 
 h1 {
+    font-family: $mg-header-font;
     font-size: $mg-font-size-base * 1.5;
 }
 
 h2 {
+    font-family: $mg-header-font;
     font-size: $mg-font-size-base * 1.25;
 }
 
@@ -31,16 +33,6 @@ body .form-control::placeholder {
 // Less spacing between label and form inputs.
 label {
     margin-bottom: $mg-spacer / 4;
-}
-
-.jumbotron {
-    h1,
-    h2,
-    h3,
-    h4,
-    h5 {
-        font-family: $mg-header-font;
-    }
 }
 
 input:-webkit-autofill,

--- a/scss/molgenis/theme-3/_custom.scss
+++ b/scss/molgenis/theme-3/_custom.scss
@@ -37,7 +37,6 @@ a:focus,
 
             .panel-title {
                 display: inline-block;
-                font-family: $mg-header-font;
                 font-size: $mg-font-size-large;
                 text-align: center;
                 vertical-align: middle;

--- a/scss/molgenis/theme-3/elements/_navbar.scss
+++ b/scss/molgenis/theme-3/elements/_navbar.scss
@@ -12,12 +12,11 @@
         li {
             font-size: $mg-navbar-font-size;
             font-weight: $mg-navbar-font-weight;
-
             vertical-align: middle;
         }
 
         > li > a {
-            font-family: $mg-header-font;
+            font-family: $mg-font-base;
             height: $mg-navbar-height;
             line-height: $mg-navbar-height;
             padding: 0 $mg-spacer;
@@ -57,7 +56,7 @@
                 content: '';
                 display: inline-block;
                 margin-left: 4px;
-                margin-top: 22px;
+                margin-top: 25px;
                 position: absolute;
                 top: 0;
             }

--- a/scss/molgenis/theme-3/modules/_data-explorer.scss
+++ b/scss/molgenis/theme-3/modules/_data-explorer.scss
@@ -39,7 +39,6 @@
         #entity-class-description,
         #entity-class-name {
             display: inline-block;
-            font-family: $mg-header-font;
             height: $mg-header-height;
             line-height: $mg-header-height;
             margin: 0;

--- a/scss/molgenis/theme-3/modules/_data-explorer.scss
+++ b/scss/molgenis/theme-3/modules/_data-explorer.scss
@@ -39,6 +39,7 @@
         #entity-class-description,
         #entity-class-name {
             display: inline-block;
+            font-family: $mg-header-font;
             height: $mg-header-height;
             line-height: $mg-header-height;
             margin: 0;

--- a/scss/molgenis/theme-4/elements/_navbar.scss
+++ b/scss/molgenis/theme-4/elements/_navbar.scss
@@ -43,7 +43,7 @@
             }
 
             .nav-link {
-                font-family: $mg-header-font;
+                font-family: $mg-font-base;
                 font-size: $mg-navbar-font-size;
                 font-weight: 400;
                 height: $mg-navbar-height;

--- a/scss/molgenis/theme-4/modules/_data-row-edit.scss
+++ b/scss/molgenis/theme-4/modules/_data-row-edit.scss
@@ -1,11 +1,4 @@
 .mod-data-row-edit {
-    legend,
-    h1,
-    h2 {
-        color: $mg-color-primary;
-        font-family: $mg-header-font;
-    }
-
     legend {
         font-size: 1.1rem;
         margin-bottom: 0;

--- a/scss/molgenis/theme-4/modules/_settings.scss
+++ b/scss/molgenis/theme-4/modules/_settings.scss
@@ -1,11 +1,4 @@
 .mod-settings {
-    legend,
-    h1,
-    h2 {
-        color: $mg-color-primary;
-        font-family: $mg-header-font;
-    }
-
     .form-group {
         > label {
             font-weight: 600;


### PR DESCRIPTION
Closes #26 
- Use header font for headers
- small tweak to align menu chevron in bs3