### PR TITLE
chore: simplify MG_THEME & allow custom themes for remote proxying

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -1,5 +1,4 @@
 COMPOSE_IGNORE_ORPHANS=True
 COMPOSE_PROJECT_NAME=mg_projects
 MG_PROXY=https://master.dev.molgenis.org
-MG_THEME_LOCAL=molgenis-blue
-MG_THEME_PROXY=bootstrap-molgenis-blue.min.css
+MG_THEME=molgenis-blue

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ file; the **.env** file. It has the following options:
 COMPOSE_PROJECT_NAME=mg_projects
 # URL of a remote Molgenis instance to proxy (use with 'yarn proxy')
 MG_PROXY=https://master.dev.molgenis.org
-# Docker service name (use with 'yarn proxy-molgenis')
+# Docker service name (use with 'yarn proxy-services-molgenis')
 # MG_PROXY=http://molgenis:8080
 # Docker host ip (use with 'yarn proxy-services')
 # MG_PROXY=http://172.19.0.1:8080
@@ -96,7 +96,7 @@ It requires a bit of setup:
   MG_PROXY=https://master.dev.molgenis.org
   # Example with yarn proxy-services; use docker host ip here:
   # MG_PROXY=http://172.19.0.1:8080
-  # Example with yarn proxy-molgenis; use docker service name here:
+  # Example with yarn proxy-services-molgenis; use docker service name here:
   # MG_PROXY=http://molgenis:8080
 
   # The theme that is being applied on the proxied host.
@@ -111,7 +111,7 @@ It requires a bit of setup:
   # When you need to test with a certain local Molgenis branch (IntelliJ)
   yarn proxy-services
   # When you want to test with a locally deployed Molgenis site
-  yarn proxy-molgenis
+  yarn proxy-services-molgenis
   ```
 
 > Use the most simple option to get started; e.g. **yarn proxy**

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd molgenis-theme
 yarn
 # Set the default config file
 cp .env.defaults .env
-# Build the selected theme (MG_THEME_LOCAL in .env)
+# Build the selected theme (MG_THEME in .env)
 yarn build
 # Build all themes at once
 yarn build-all
@@ -55,9 +55,7 @@ MG_PROXY=https://master.dev.molgenis.org
 # MG_PROXY=http://172.19.0.1:8080
 
 # The local theme to serve and watch (/theme/...):
-MG_THEME_LOCAL=molgenis-blue
-# The proxy CSS theme to replace:
-MG_THEME_PROXY=bootstrap-molgenis-blue.min.css
+MG_THEME=molgenis-blue
 ```
 
 ## Development
@@ -74,7 +72,7 @@ MG_THEME_PROXY=bootstrap-molgenis-blue.min.css
 
   ```bash
   # vim docker/.env
-  MG_THEME_LOCAL=molgenis-red
+  MG_THEME=molgenis-red
   ```
 
 * Build the theme
@@ -102,11 +100,7 @@ It requires a bit of setup:
   # MG_PROXY=http://molgenis:8080
 
   # The theme that is being applied on the proxied host.
-  MG_THEME_LOCAL=molgenis-red
-  # The theme that is in use by the proxy
-  # Check view-source:https://master.dev.molgenis.org/ for
-  # the current theme in the <head> section
-  MG_THEME_PROXY=bootstrap-molgenis-blue.min.css
+  MG_THEME=molgenis-blue
   ```
 
 * Start the proxy in one of the three different setups:

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -36,7 +36,7 @@ tasks.build = new Task('build', async function() {
         const themes = await (await fs.readdir(settings.dir.themes, {withFileTypes: true})).filter((i) => i.isDirectory())
         asyncTasks.push(themes.map((theme) => tasks.scss.start(theme.name)))
     } else {
-        asyncTasks.push(tasks.scss.start(settings.MG_THEME_LOCAL))
+        asyncTasks.push(tasks.scss.start(settings.MG_THEME))
     }
 
     await Promise.all(asyncTasks)
@@ -71,11 +71,12 @@ tasks.serve = new Task('serve', async function() {
         app.listen({host: '127.0.0.1', port: 35729}, () => resolve)
 
         chokidar.watch([
-            path.join(settings.dir.themes, settings.MG_THEME_LOCAL, '**', '*.scss'),
+            path.join(settings.dir.themes, settings.MG_THEME, '**', '*.scss'),
             path.join(settings.dir.base, 'scss', '**', '*.scss')
         ]).on('change', async(file) => {
-            await tasks.scss.start(settings.MG_THEME_LOCAL)
-            tinylr.changed(settings.MG_THEME_PROXY)
+            await tasks.scss.start(settings.MG_THEME)
+            tinylr.changed(`mg-${settings.MG_THEME}-3.css`)
+            tinylr.changed(`mg-${settings.MG_THEME}-4.css`)
         })
     })
 })
@@ -132,7 +133,7 @@ tasks.scss = new Task('scss', async function(ep) {
         .command('config', 'list build config', () => {}, () => {})  // Build info is shown when the task executes.
         .command('serve', `development mode`, () => {}, () => {tasks.serve.start()})
         .command('index', `build theme index file`, () => {}, () => {tasks.themeIndex.start()})
-        .command('scss', `build stylesheets for ${settings.MG_THEME_LOCAL}`, () => {}, () => {tasks.scss.start(settings.MG_THEME_LOCAL)})
+        .command('scss', `build stylesheets for ${settings.MG_THEME}`, () => {}, () => {tasks.scss.start(settings.MG_THEME)})
         .command('service', `start theme generator service`, () => {}, () => {
             scssService(settings)
         })

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -36,8 +36,7 @@ export const buildInfo = async function(cli) {
                 label: chalk.bold('env'),
                 nodes: [
                     {label: `${'MG_PROXY'.padEnd(15, ' ')} ${cli.settings.MG_PROXY}`},
-                    {label: `${'MG_THEME_LOCAL'.padEnd(15, ' ')} ${cli.settings.MG_THEME_LOCAL}`},
-                    {label: `${'MG_THEME_PROXY'.padEnd(15, ' ')} ${cli.settings.MG_THEME_PROXY}`},
+                    {label: `${'MG_THEME'.padEnd(15, ' ')} ${cli.settings.MG_THEME}`}
                 ]
             }
         ]

--- a/docker/dc-proxy.yml
+++ b/docker/dc-proxy.yml
@@ -6,8 +6,7 @@ services:
     container_name: mg_projects_nginx
     environment:
       MG_PROXY: ${MG_PROXY:-http://172.19.0.1:8080/}
-      MG_THEME_LOCAL: ${MG_THEME_LOCAL:-molgenis-blue}
-      MG_THEME_PROXY: ${MG_THEME_PROXY:-bootstrap-molgenis-blue.min.css}
+      MG_THEME: ${MG_THEME:-molgenis-blue}
     image: nginx
     networks:
       - mg_projects

--- a/docker/nginx/localhost.tpl
+++ b/docker/nginx/localhost.tpl
@@ -34,11 +34,11 @@ server {
   }
 
   # Rewrite in case of using a remote proxy; e.g. master.dev.molgenis.org
-  location ~ ^/@molgenis-ui/molgenis-theme/dist/themes/mg-molgenis-blue-(?<version>[0-9]+).css {
+  location ~ ^/@molgenis-ui/molgenis-theme/dist/themes/mg-${MG_THEME}-(?<version>[0-9]+).css {
       root /usr/share/nginx/html/;
       add_header Last-Modified $date_gmt;
       add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
-      rewrite ^ /dist/themes/mg-${MG_THEME_LOCAL}-$version.css break;
+      rewrite ^ /dist/themes/mg-${MG_THEME}-$version.css break;
   }
 
   location /@molgenis-ui/ {


### PR DESCRIPTION
Config: 

```
COMPOSE_IGNORE_ORPHANS=True
COMPOSE_PROJECT_NAME=mg_projects
MG_PROXY=https://master.dev.molgenis.org
MG_THEME=molgenis-blue
```

Test with:
```
yarn proxy
```
check whether livereload kicks in after changing a variable, e.g. $mg-color-primary while using the correct theme (e.g. green, when green is selected in the theme-manager)