### PR TITLE
fix: proxy source maps & config loading with proxy command

### DIFF
--- a/docker/nginx/localhost.tpl
+++ b/docker/nginx/localhost.tpl
@@ -34,11 +34,11 @@ server {
   }
 
   # Rewrite in case of using a remote proxy; e.g. master.dev.molgenis.org
-  location ~ ^/@molgenis-ui/molgenis-theme/dist/themes/mg-${MG_THEME}-(?<version>[0-9]+).css {
+  location ~ ^/@molgenis-ui/molgenis-theme/dist/themes/mg-${MG_THEME}-(?<version>[0-9]+).(?<extension>[a-z]+.[a-z]+) {
       root /usr/share/nginx/html/;
       add_header Last-Modified $date_gmt;
       add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
-      rewrite ^ /dist/themes/mg-${MG_THEME}-$version.css break;
+      rewrite ^ /dist/themes/mg-${MG_THEME}-$version.$extension break;
   }
 
   location /@molgenis-ui/ {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build-all": "node cli/cli.js build --all --optimize",
     "cli": "node cli/cli.js",
     "lint": "stylelint \"scss/**/*.scss\"",
-    "proxy": "docker-compose --env-file .env --file ./docker/dc-proxy.yml up",
+    "proxy": "COMPOSE_FILE=docker/dc-proxy.yml docker-compose --env-file ../.env --project-directory ./docker up",
     "proxy-services": "COMPOSE_FILE=docker/dc-proxy.yml:docker/dc-services.yml docker-compose --env-file ../.env --project-directory ./docker up",
     "proxy-services-molgenis": "COMPOSE_FILE=docker/dc-proxy.yml:docker/dc-services.yml:docker/dc-molgenis.yml docker-compose --env-file ../.env --project-directory ./docker up",
     "test-release": "semantic-release --dry-run",


### PR DESCRIPTION
Before, http://localhost/@molgenis-ui/molgenis-theme/dist/themes/mg-molgenis-blue-4.css.map failed to load, due to 
an incomplete location regex. This caused sourcemaps to fail loading during development. Check devtools to see if the css rules point to the original scss source location. Also, the .env file didn't load properly(it used the defaults in dc-proxy.yml).