### PR TITLE
fix: set correct menu collapse point

### DIFF
--- a/scss/molgenis/theme-3/_custom.scss
+++ b/scss/molgenis/theme-3/_custom.scss
@@ -129,7 +129,7 @@ body > nav > header {
 }
 
 // Fix: make scrolling in mobile menu posible
-@media (max-width: 1222px) {
+@media (max-width: #{$grid-float-breakpoint}) {
     .navbar-fixed-top {
         max-height: 100vh;
         overflow: auto;


### PR DESCRIPTION
The bootstrap 3 menu is broken between $grid-float-breakpoint `1127px` and 1222px 
